### PR TITLE
Change from Spray to Akka HTTP to allow for usage of current Akka version

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -16,15 +16,21 @@ lazy val root = project.in(file(".")).
     publishLocal := {}
   )
 
+val akkaVersion = "2.4.10"
+
 lazy val renesca = crossProject.in(file("."))
   .configs(IntegrationTest)
   .settings(Defaults.itSettings: _*)
   .settings(sonatypeSettings: _*)
   .jvmSettings(
     libraryDependencies ++= (
-      "io.spray" %% "spray-client" % "1.3.3" ::
-      "io.spray" %% "spray-json" % "1.3.2" ::
-      "com.typesafe.akka" %% "akka-actor" % "2.3.15" ::
+      //"io.spray" %% "spray-client" % "1.3.3" ::
+      //"io.spray" %% "spray-json" % "1.3.2" ::
+      //"com.typesafe.akka" %% "akka-actor" % "2.3.15" ::
+      "com.typesafe.akka" %% "akka-actor" % akkaVersion ::
+      "com.typesafe.akka" %% "akka-http-core" % akkaVersion ::
+      "com.typesafe.akka" %% "akka-http-experimental" % akkaVersion ::
+      "com.typesafe.akka" % "akka-http-spray-json-experimental_2.11" % akkaVersion ::
       "org.specs2" %% "specs2-core" % "3.8.4" % "it,test" ::
       ("com.github.httpmock" % "mock-http-server-webapp" % "1.1.9" artifacts (Artifact("mock-http-server-webapp", "jar", "jar")) classifier "") ::
       "com.github.httpmock" %% "httpmock-specs" % "0.6.1" % "it,test" ::

--- a/jvm/src/it/scala/renesca/IntegrationSpecification.scala
+++ b/jvm/src/it/scala/renesca/IntegrationSpecification.scala
@@ -1,10 +1,10 @@
 package renesca
 
+import akka.http.scaladsl.model.headers.BasicHttpCredentials
 import akka.util.Timeout
 import org.specs2.execute.{AsResult, Result, ResultExecution, Skipped}
 import org.specs2.mutable.Specification
 import org.specs2.specification._
-import spray.http.BasicHttpCredentials
 
 import scala.concurrent.duration._
 


### PR DESCRIPTION
You will need to manually fix build.sbt as I'm not sure how to build this, the important part being RestService.scala
